### PR TITLE
Improve device binding selection clarity

### DIFF
--- a/Source/Gui/MainWindow.cpp
+++ b/Source/Gui/MainWindow.cpp
@@ -21,17 +21,34 @@
 #include <QScreen>
 #include <QPainter>
 #include <QMessageBox>
+#include <QStringList>
 
 #include <Config.h>
 #include "../Helper.h"
 #include "../Error.h"
 #include "../Application.h"
 #include "../Core/AppleCP.h"
+#include "../Core/Settings.h"
 #include "SelectWindow.h"
 
 using namespace std::chrono_literals;
 
 namespace Gui {
+
+namespace {
+QString FormatDeviceAddress(uint64_t address)
+{
+    QString hex = QString::number(static_cast<qulonglong>(address), 16)
+                       .toUpper()
+                       .rightJustified(12, QLatin1Char('0'));
+
+    for (int index = hex.size() - 2; index > 0; index -= 2) {
+        hex.insert(index, QLatin1Char(':'));
+    }
+
+    return hex;
+}
+} // namespace
 
 class CloseButton : public QWidget
 {
@@ -476,6 +493,9 @@ void MainWindow::BindDevice()
 {
     LOG(Info, "BindDevice");
 
+    const auto settings = Core::Settings::GetCurrent();
+    const auto boundAddress = settings.device_address;
+
     const auto devices = Core::AirPods::GetDevices();
     if (devices.empty()) {
         QMessageBox::warning(
@@ -486,19 +506,53 @@ void MainWindow::BindDevice()
     }
 
     int selectedIndex = 0;
+    int connectedIndex = -1;
+    int boundIndex = -1;
 
-    if (devices.size() > 1) {
-        QStringList deviceNames;
-        for (const auto &device : devices) {
-            auto deviceName = device.GetName();
+    QStringList deviceNames;
+    deviceNames.reserve(static_cast<int>(devices.size()));
 
-            LOG(Trace, "Device name: '{}'", deviceName);
-            LOG(Trace, "GetProductId: '{}' GetVendorId: '{}'", device.GetProductId(),
-                device.GetVendorId());
-            deviceNames.append(QString::fromStdString(deviceName));
+    for (int index = 0; index < static_cast<int>(devices.size()); ++index) {
+        const auto &device = devices.at(index);
+
+        LOG(Trace, "Device name: '{}'", device.GetName());
+        LOG(Trace, "GetProductId: '{}' GetVendorId: '{}'", device.GetProductId(),
+            device.GetVendorId());
+
+        QString deviceName = QString::fromStdString(device.GetName());
+        if (deviceName.isEmpty()) {
+            deviceName = tr("AirPods");
         }
 
-        SelectWindow selector{tr("Please select your AirPods device below."), deviceNames, this};
+        const auto addressText = FormatDeviceAddress(device.GetAddress());
+        deviceName += QStringLiteral(" · %1").arg(addressText);
+
+        const bool isConnected =
+            device.GetConnectionState() == Core::Bluetooth::DeviceState::Connected;
+        if (isConnected) {
+            deviceName += tr(" (Connected)");
+            if (connectedIndex == -1) {
+                connectedIndex = index;
+            }
+        }
+
+        if (device.GetAddress() == boundAddress) {
+            boundIndex = index;
+        }
+
+        deviceNames.append(deviceName);
+    }
+
+    if (boundIndex != -1) {
+        selectedIndex = boundIndex;
+    }
+    else if (connectedIndex != -1) {
+        selectedIndex = connectedIndex;
+    }
+
+    if (devices.size() > 1) {
+        SelectWindow selector{
+            tr("Please select your AirPods device below."), deviceNames, this, selectedIndex};
         if (selector.exec() == -1) {
             LOG(Warn, "selector.exec() == -1");
             return;
@@ -514,6 +568,27 @@ void MainWindow::BindDevice()
     }
 
     const auto &selectedDevice = devices.at(selectedIndex);
+
+    if (boundAddress != 0 && selectedDevice.GetAddress() != boundAddress) {
+        QString previousBinding;
+        if (boundIndex >= 0 && boundIndex < deviceNames.size()) {
+            previousBinding = deviceNames.at(boundIndex);
+        }
+        else {
+            previousBinding = FormatDeviceAddress(boundAddress);
+        }
+
+        const auto confirmation = QMessageBox::question(
+            this, Config::ProgramName,
+            tr("Switch binding from %1 to %2?")
+                .arg(previousBinding, deviceNames.at(selectedIndex)),
+            QMessageBox::Yes | QMessageBox::No);
+
+        if (confirmation != QMessageBox::Yes) {
+            LOG(Info, "User canceled AirPods binding change.");
+            return;
+        }
+    }
 
     LOG(Info, "Selected device index: '{}', device name: '{}'. Bound to this device.",
         selectedIndex, selectedDevice.GetName());

--- a/Source/Gui/SelectWindow.cpp
+++ b/Source/Gui/SelectWindow.cpp
@@ -22,7 +22,8 @@
 
 namespace Gui {
 
-SelectWindow::SelectWindow(const QString &title, const QStringList &items, QWidget *parent)
+SelectWindow::SelectWindow(
+    const QString &title, const QStringList &items, QWidget *parent, int defaultIndex)
     : QDialog{parent}
 {
     _ui.setupUi(this);
@@ -40,7 +41,13 @@ SelectWindow::SelectWindow(const QString &title, const QStringList &items, QWidg
 
     _ui.label->setText(title);
     _ui.listWidget->addItems(items);
-    _ui.listWidget->item(0)->setSelected(true);
+
+    if (defaultIndex < 0 || defaultIndex >= _ui.listWidget->count()) {
+        defaultIndex = 0;
+    }
+
+    _ui.listWidget->setCurrentRow(defaultIndex);
+    _ui.listWidget->item(defaultIndex)->setSelected(true);
 }
 
 bool SelectWindow::HasResult() const

--- a/Source/Gui/SelectWindow.h
+++ b/Source/Gui/SelectWindow.h
@@ -33,7 +33,9 @@ class SelectWindow : public QDialog
     Q_OBJECT
 
 public:
-    SelectWindow(const QString &title, const QStringList &items, QWidget *parent = nullptr);
+    SelectWindow(
+        const QString &title, const QStringList &items, QWidget *parent = nullptr,
+        int defaultIndex = 0);
 
     bool HasResult() const;
     int GetSeletedIndex() const;


### PR DESCRIPTION
### **User description**
## Summary
- show Bluetooth addresses and connection status when listing AirPods during binding
- default selection to the currently bound or connected device to avoid weak-signal picks
- confirm with the user before switching the binding to a different device

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68cbcb927d848330b8b09333f37cb9cc


___

### **PR Type**
Enhancement


___

### **Description**
- Display Bluetooth addresses and connection status in device list

- Default selection to currently bound or connected device

- Confirm binding change before switching to different device

- Add device address formatting utility function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Device List"] --> B["Format with Address<br/>& Status"]
  B --> C["Select Default<br/>Bound/Connected"]
  C --> D["Show Confirmation<br/>Dialog"]
  D --> E["Bind Device"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MainWindow.cpp</strong><dd><code>Add device addresses, status, and binding confirmation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Gui/MainWindow.cpp

<ul><li>Added <code>FormatDeviceAddress()</code> utility function to convert 64-bit <br>addresses to colon-separated hex format<br> <li> Enhanced device listing to include Bluetooth addresses and connection <br>status indicators<br> <li> Implemented smart default selection prioritizing bound device, then <br>connected device<br> <li> Added confirmation dialog when switching binding from one device to <br>another<br> <li> Refactored device enumeration loop to track bound and connected device <br>indices</ul>


</details>


  </td>
  <td><a href="https://github.com/zzixxxx/AirPodsDesktop/pull/1/files#diff-91d0f34a57fb9e357017456ad9d697da947fe6f42179e3df34366670016043be">+85/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SelectWindow.cpp</strong><dd><code>Support custom default selection in dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Gui/SelectWindow.cpp

<ul><li>Added <code>defaultIndex</code> parameter to constructor for pre-selecting items<br> <li> Changed from hardcoded first item selection to dynamic default index <br>selection<br> <li> Added validation to ensure default index is within valid range<br> <li> Use <code>setCurrentRow()</code> in addition to <code>setSelected()</code> for proper selection <br>state</ul>


</details>


  </td>
  <td><a href="https://github.com/zzixxxx/AirPodsDesktop/pull/1/files#diff-439f96cb8ea04b286b1073426180311ef055d25f1a44dbb02fb24a265db0ed65">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SelectWindow.h</strong><dd><code>Add defaultIndex parameter to constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Source/Gui/SelectWindow.h

<ul><li>Added optional <code>defaultIndex</code> parameter to constructor signature with <br>default value of 0<br> <li> Updated constructor declaration to support custom default item <br>selection</ul>


</details>


  </td>
  <td><a href="https://github.com/zzixxxx/AirPodsDesktop/pull/1/files#diff-e372ef1dc35bd9c2d03b2dc3b9a7c75095d662a8942124b976904ef38870c9b5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

